### PR TITLE
u96v2_sbc_dualcam: add bgr support to capture pipeline / fix vitis interrupts

### DIFF
--- a/boards/u96v2_sbc/dualcam/u96v2_sbc_dualcam.tcl
+++ b/boards/u96v2_sbc/dualcam/u96v2_sbc_dualcam.tcl
@@ -212,8 +212,8 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    #create_hier_cell_interrupt_concat [current_bd_instance .] interrupt_concat
    #connect_bd_net -net interrupt_concat_dout [get_bd_pins axi_intc_0/intr] [get_bd_pins interrupt_concat/dout]
    #
-   set_property -dict [list CONFIG.NUM_PORTS {3}] [get_bd_cells xlconcat_0]
-   connect_bd_net [get_bd_pins xlconcat_0/In0] [get_bd_pins axi_intc_0/irq]
+   set_property -dict [list CONFIG.NUM_PORTS {7}] [get_bd_cells xlconcat_0]
+   connect_bd_net [get_bd_pins xlconcat_0/In6] [get_bd_pins axi_intc_0/irq]
    #
    apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/zynq_ultra_ps_e_0/pl_clk0 (100 MHz)} Clk_slave {/zynq_ultra_ps_e_0/pl_clk0 (100 MHz)} Clk_xbar {/zynq_ultra_ps_e_0/pl_clk0 (100 MHz)} Master {/zynq_ultra_ps_e_0/M_AXI_HPM0_FPD} Slave {/axi_intc_0/s_axi} ddr_seg {Auto} intc_ip {/ps8_0_axi_periph} master_apm {0}}  [get_bd_intf_pins axi_intc_0/s_axi]
 
@@ -461,11 +461,11 @@ proc create_hier_cell_GPIO { parentCell nameHier } {
   create_bd_pin -dir O -from 0 -to 0 ICP3_I2C_ID_SELECT
   create_bd_pin -dir O -from 0 -to 0 SP3
   create_bd_pin -dir O -from 0 -to 0 TRG_INPUT
-  create_bd_pin -dir O -from 0 -to 0 VPSS_RESETn
-  create_bd_pin -dir I -type clk clk200
-  create_bd_pin -dir O -from 0 -to 0 frame_buffer_rd_resetn
+  create_bd_pin -dir I -type clk clk100
   create_bd_pin -dir O -from 0 -to 0 frame_buffer_wr_resetn
   create_bd_pin -dir I -type rst s_axi_aresetn
+  create_bd_pin -dir O -from 0 -to 0 vpss_csc_resetn
+  create_bd_pin -dir O -from 0 -to 0 vpss_scaler_resetn
 
   # Create instance: axi_gpio_0, and set properties
   set axi_gpio_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_gpio:2.0 axi_gpio_0 ]
@@ -532,21 +532,19 @@ proc create_hier_cell_GPIO { parentCell nameHier } {
 
   # Create port connections
   connect_bd_net -net axi_gpio_0_gpio_io_o [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_0/Din] [get_bd_pins xlslice_1/Din] [get_bd_pins xlslice_2/Din] [get_bd_pins xlslice_3/Din] [get_bd_pins xlslice_4/Din] [get_bd_pins xlslice_5/Din]
-  connect_bd_net -net clk_wiz_clk_out1 [get_bd_pins clk200] [get_bd_pins axi_gpio_0/s_axi_aclk]
-  connect_bd_net -net rst_clk_wiz_100M_peripheral_aresetn [get_bd_pins s_axi_aresetn] [get_bd_pins axi_gpio_0/s_axi_aresetn]
+  connect_bd_net -net clk_wiz_clk_out1 [get_bd_pins clk100] [get_bd_pins axi_gpio_0/s_axi_aclk]
+  connect_bd_net -net s_axi_aresetn_1 [get_bd_pins s_axi_aresetn] [get_bd_pins axi_gpio_0/s_axi_aresetn]
   connect_bd_net -net xlslice_0_Dout [get_bd_pins TRG_INPUT] [get_bd_pins xlslice_0/Dout]
   connect_bd_net -net xlslice_1_Dout [get_bd_pins ICP3_I2C_ID_SELECT] [get_bd_pins xlslice_1/Dout]
   connect_bd_net -net xlslice_2_Dout [get_bd_pins SP3] [get_bd_pins xlslice_2/Dout]
   connect_bd_net -net xlslice_3_Dout [get_bd_pins frame_buffer_wr_resetn] [get_bd_pins xlslice_3/Dout]
-  connect_bd_net -net xlslice_4_Dout [get_bd_pins frame_buffer_rd_resetn] [get_bd_pins xlslice_4/Dout]
-  connect_bd_net -net xlslice_5_Dout [get_bd_pins VPSS_RESETn] [get_bd_pins xlslice_5/Dout]
-
-   save_bd_design
+  connect_bd_net -net xlslice_4_Dout [get_bd_pins vpss_csc_resetn] [get_bd_pins xlslice_4/Dout]
+  connect_bd_net -net xlslice_5_Dout [get_bd_pins vpss_scaler_resetn] [get_bd_pins xlslice_5/Dout]
 
   # Restore current instance
   current_bd_instance $oldCurInst
 }
-  
+
 # Hierarchical cell: CAPTURE_PIPELINE
 proc create_hier_cell_CAPTURE_PIPELINE { parentCell nameHier } {
 
@@ -582,26 +580,29 @@ proc create_hier_cell_CAPTURE_PIPELINE { parentCell nameHier } {
   current_bd_instance $hier_obj
 
   # Create interface pins
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 csc_ctrl
+
   create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 csirxss_s_axi
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 frmbuf_ctrl
 
   create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 m_axi_mm_video
 
   create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:mipi_phy_rtl:1.0 mipi_phy_if_0
 
-  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 s_axi_CTRL1
-
-  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 s_axi_ctrl
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 scaler_ctrl
 
 
   # Create pins
-  create_bd_pin -dir I -type rst aux_reset_in
-  create_bd_pin -dir I -type rst aux_reset_in_0
   create_bd_pin -dir O -type intr csirxss_csi_irq
   create_bd_pin -dir I dcm_locked
   create_bd_pin -dir I -type clk dphy_clk_200M
   create_bd_pin -dir I -type rst ext_reset_in
+  create_bd_pin -dir I -type rst frmbuf_resetn
   create_bd_pin -dir O -type intr interrupt
   create_bd_pin -dir I -type rst video_aresetn
+  create_bd_pin -dir I -type rst vpss_csc_resetn
+  create_bd_pin -dir I -type rst vpss_scaler_resetn
 
   # Create instance: axis_subset_converter_1, and set properties
   set axis_subset_converter_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_subset_converter:1.1 axis_subset_converter_1 ]
@@ -631,7 +632,6 @@ proc create_hier_cell_CAPTURE_PIPELINE { parentCell nameHier } {
  ] $axis_subset_converter_1
 
   # Create instance: mipi_csi2_rx_subsyst_0, and set properties
-#TC   set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:5.0 mipi_csi2_rx_subsyst_0 ]
   set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:5.1 mipi_csi2_rx_subsyst_0 ]
   set_property -dict [ list \
    CONFIG.AXIS_TDEST_WIDTH {4} \
@@ -679,19 +679,21 @@ proc create_hier_cell_CAPTURE_PIPELINE { parentCell nameHier } {
   # Create instance: proc_sys_reset_2, and set properties
   set proc_sys_reset_2 [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 proc_sys_reset_2 ]
 
+  # Create instance: proc_sys_reset_3, and set properties
+  set proc_sys_reset_3 [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 proc_sys_reset_3 ]
+
   # Create instance: v_frmbuf_wr_0, and set properties
-#TC  set v_frmbuf_wr_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_frmbuf_wr:2.1 v_frmbuf_wr_0 ]
   set v_frmbuf_wr_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_frmbuf_wr:2.2 v_frmbuf_wr_0 ]
   set_property -dict [ list \
    CONFIG.AXIMM_DATA_WIDTH {128} \
    CONFIG.C_M_AXI_MM_VIDEO_DATA_WIDTH {128} \
-   CONFIG.HAS_BGR8 {0} \
+   CONFIG.HAS_BGR8 {1} \
    CONFIG.HAS_BGRX8 {0} \
    CONFIG.HAS_INTERLACED {0} \
    CONFIG.HAS_RGB8 {0} \
    CONFIG.HAS_RGBX8 {0} \
    CONFIG.HAS_UYVY8 {1} \
-   CONFIG.HAS_Y8 {0} \
+   CONFIG.HAS_Y8 {1} \
    CONFIG.HAS_YUV8 {0} \
    CONFIG.HAS_YUVX8 {0} \
    CONFIG.HAS_YUYV8 {1} \
@@ -701,12 +703,26 @@ proc create_hier_cell_CAPTURE_PIPELINE { parentCell nameHier } {
    CONFIG.SAMPLES_PER_CLOCK {2} \
  ] $v_frmbuf_wr_0
 
-  # Create instance: v_proc_ss_0, and set properties
-#TC  set v_proc_ss_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_proc_ss:2.2 v_proc_ss_0 ]
-  set v_proc_ss_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_proc_ss:2.3 v_proc_ss_0 ]
+  # Create instance: v_proc_ss_csc_0, and set properties
+  set v_proc_ss_csc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_proc_ss:2.3 v_proc_ss_csc_0 ]
   set_property -dict [ list \
-   CONFIG.C_COLORSPACE_SUPPORT {0} \
+   CONFIG.C_COLORSPACE_SUPPORT {1} \
    CONFIG.C_ENABLE_CSC {false} \
+   CONFIG.C_ENABLE_DMA {false} \
+   CONFIG.C_ENABLE_INTERLACED {false} \
+   CONFIG.C_H_SCALER_TAPS {8} \
+   CONFIG.C_MAX_DATA_WIDTH {8} \
+   CONFIG.C_SAMPLES_PER_CLK {2} \
+   CONFIG.C_SCALER_ALGORITHM {2} \
+   CONFIG.C_TOPOLOGY {3} \
+   CONFIG.C_V_SCALER_TAPS {8} \
+ ] $v_proc_ss_csc_0
+
+  # Create instance: v_proc_ss_scaler_0, and set properties
+  set v_proc_ss_scaler_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_proc_ss:2.3 v_proc_ss_scaler_0 ]
+  set_property -dict [ list \
+   CONFIG.C_COLORSPACE_SUPPORT {1} \
+   CONFIG.C_ENABLE_CSC {true} \
    CONFIG.C_ENABLE_DMA {false} \
    CONFIG.C_ENABLE_INTERLACED {false} \
    CONFIG.C_H_SCALER_TAPS {8} \
@@ -715,34 +731,33 @@ proc create_hier_cell_CAPTURE_PIPELINE { parentCell nameHier } {
    CONFIG.C_SCALER_ALGORITHM {2} \
    CONFIG.C_TOPOLOGY {0} \
    CONFIG.C_V_SCALER_TAPS {8} \
- ] $v_proc_ss_0
+ ] $v_proc_ss_scaler_0
 
   # Create interface connections
+  connect_bd_intf_net -intf_net Conn1 [get_bd_intf_pins csc_ctrl] [get_bd_intf_pins v_proc_ss_csc_0/s_axi_ctrl]
   connect_bd_intf_net -intf_net S00_AXI_1 [get_bd_intf_pins m_axi_mm_video] [get_bd_intf_pins v_frmbuf_wr_0/m_axi_mm_video]
-  connect_bd_intf_net -intf_net ZYNQ_M01_AXI [get_bd_intf_pins s_axi_CTRL1] [get_bd_intf_pins v_frmbuf_wr_0/s_axi_CTRL]
+  connect_bd_intf_net -intf_net ZYNQ_M01_AXI [get_bd_intf_pins frmbuf_ctrl] [get_bd_intf_pins v_frmbuf_wr_0/s_axi_CTRL]
   connect_bd_intf_net -intf_net ZYNQ_M09_AXI [get_bd_intf_pins csirxss_s_axi] [get_bd_intf_pins mipi_csi2_rx_subsyst_0/csirxss_s_axi]
-  connect_bd_intf_net -intf_net ZYNQ_M10_AXI [get_bd_intf_pins s_axi_ctrl] [get_bd_intf_pins v_proc_ss_0/s_axi_ctrl]
-  connect_bd_intf_net -intf_net axis_subset_converter_1_M_AXIS [get_bd_intf_pins axis_subset_converter_1/M_AXIS] [get_bd_intf_pins v_proc_ss_0/s_axis]
+  connect_bd_intf_net -intf_net ZYNQ_M10_AXI [get_bd_intf_pins scaler_ctrl] [get_bd_intf_pins v_proc_ss_scaler_0/s_axi_ctrl]
+  connect_bd_intf_net -intf_net axis_subset_converter_1_M_AXIS [get_bd_intf_pins axis_subset_converter_1/M_AXIS] [get_bd_intf_pins v_proc_ss_csc_0/s_axis]
   connect_bd_intf_net -intf_net mipi_csi2_rx_subsyst_0_video_out [get_bd_intf_pins axis_subset_converter_1/S_AXIS] [get_bd_intf_pins mipi_csi2_rx_subsyst_0/video_out]
   connect_bd_intf_net -intf_net mipi_phy_if_0_1 [get_bd_intf_pins mipi_phy_if_0] [get_bd_intf_pins mipi_csi2_rx_subsyst_0/mipi_phy_if]
-  connect_bd_intf_net -intf_net v_proc_ss_0_m_axis [get_bd_intf_pins v_frmbuf_wr_0/s_axis_video] [get_bd_intf_pins v_proc_ss_0/m_axis]
+  connect_bd_intf_net -intf_net v_proc_ss_0_m_axis [get_bd_intf_pins v_frmbuf_wr_0/s_axis_video] [get_bd_intf_pins v_proc_ss_scaler_0/m_axis]
+  connect_bd_intf_net -intf_net v_proc_ss_csc_0_m_axis [get_bd_intf_pins v_proc_ss_csc_0/m_axis] [get_bd_intf_pins v_proc_ss_scaler_0/s_axis]
 
   # Create port connections
   connect_bd_net -net GPIO_frame_buffer_resetn [get_bd_pins axis_subset_converter_1/aresetn] [get_bd_pins proc_sys_reset_1/peripheral_aresetn] [get_bd_pins v_frmbuf_wr_0/ap_rst_n]
   connect_bd_net -net In1_1 [get_bd_pins interrupt] [get_bd_pins v_frmbuf_wr_0/interrupt]
-  connect_bd_net -net aux_reset_in_0_1 [get_bd_pins aux_reset_in_0] [get_bd_pins proc_sys_reset_2/aux_reset_in]
-  connect_bd_net -net aux_reset_in_1 [get_bd_pins aux_reset_in] [get_bd_pins proc_sys_reset_1/aux_reset_in]
-  connect_bd_net -net clk_wiz_clk_out1 [get_bd_pins dphy_clk_200M] [get_bd_pins axis_subset_converter_1/aclk] [get_bd_pins mipi_csi2_rx_subsyst_0/dphy_clk_200M] [get_bd_pins mipi_csi2_rx_subsyst_0/lite_aclk] [get_bd_pins mipi_csi2_rx_subsyst_0/video_aclk] [get_bd_pins proc_sys_reset_1/slowest_sync_clk] [get_bd_pins proc_sys_reset_2/slowest_sync_clk] [get_bd_pins v_frmbuf_wr_0/ap_clk] [get_bd_pins v_proc_ss_0/aclk_axis] [get_bd_pins v_proc_ss_0/aclk_ctrl]
-  connect_bd_net -net dcm_locked_1 [get_bd_pins dcm_locked] [get_bd_pins proc_sys_reset_1/dcm_locked] [get_bd_pins proc_sys_reset_2/dcm_locked]
-  connect_bd_net -net ext_reset_in_1 [get_bd_pins ext_reset_in] [get_bd_pins proc_sys_reset_1/ext_reset_in] [get_bd_pins proc_sys_reset_2/ext_reset_in]
+  connect_bd_net -net aux_reset_in_1 [get_bd_pins frmbuf_resetn] [get_bd_pins proc_sys_reset_1/aux_reset_in]
+  connect_bd_net -net clk_wiz_clk_out1 [get_bd_pins dphy_clk_200M] [get_bd_pins axis_subset_converter_1/aclk] [get_bd_pins mipi_csi2_rx_subsyst_0/dphy_clk_200M] [get_bd_pins mipi_csi2_rx_subsyst_0/lite_aclk] [get_bd_pins mipi_csi2_rx_subsyst_0/video_aclk] [get_bd_pins proc_sys_reset_1/slowest_sync_clk] [get_bd_pins proc_sys_reset_2/slowest_sync_clk] [get_bd_pins proc_sys_reset_3/slowest_sync_clk] [get_bd_pins v_frmbuf_wr_0/ap_clk] [get_bd_pins v_proc_ss_csc_0/aclk] [get_bd_pins v_proc_ss_scaler_0/aclk_axis] [get_bd_pins v_proc_ss_scaler_0/aclk_ctrl]
+  connect_bd_net -net dcm_locked_1 [get_bd_pins dcm_locked] [get_bd_pins proc_sys_reset_1/dcm_locked] [get_bd_pins proc_sys_reset_2/dcm_locked] [get_bd_pins proc_sys_reset_3/dcm_locked]
+  connect_bd_net -net ext_reset_in_1 [get_bd_pins ext_reset_in] [get_bd_pins proc_sys_reset_1/ext_reset_in] [get_bd_pins proc_sys_reset_2/ext_reset_in] [get_bd_pins proc_sys_reset_3/ext_reset_in]
   connect_bd_net -net mipi_csi2_rx_subsyst_0_csirxss_csi_irq [get_bd_pins csirxss_csi_irq] [get_bd_pins mipi_csi2_rx_subsyst_0/csirxss_csi_irq]
-  connect_bd_net -net proc_sys_reset_2_peripheral_aresetn [get_bd_pins proc_sys_reset_2/peripheral_aresetn] [get_bd_pins v_proc_ss_0/aresetn_ctrl]
-  connect_bd_net -net rst_clk_wiz_100M_peripheral_aresetn [get_bd_pins video_aresetn] [get_bd_pins mipi_csi2_rx_subsyst_0/lite_aresetn] [get_bd_pins mipi_csi2_rx_subsyst_0/video_aresetn]
-
-  # Perform GUI Layout
-  regenerate_bd_layout -hierarchy [get_bd_cells /CAPTURE_PIPELINE]
-
-  save_bd_design
+  connect_bd_net -net proc_sys_reset_2_peripheral_aresetn [get_bd_pins proc_sys_reset_2/peripheral_aresetn] [get_bd_pins v_proc_ss_scaler_0/aresetn_ctrl]
+  connect_bd_net -net proc_sys_reset_3_peripheral_aresetn [get_bd_pins proc_sys_reset_3/peripheral_aresetn] [get_bd_pins v_proc_ss_csc_0/aresetn]
+  connect_bd_net -net video_aresetn_1 [get_bd_pins video_aresetn] [get_bd_pins mipi_csi2_rx_subsyst_0/lite_aresetn] [get_bd_pins mipi_csi2_rx_subsyst_0/video_aresetn]
+  connect_bd_net -net vpss_csc_resetn_1 [get_bd_pins vpss_csc_resetn] [get_bd_pins proc_sys_reset_3/aux_reset_in]
+  connect_bd_net -net vpss_scaler_resetn [get_bd_pins vpss_scaler_resetn] [get_bd_pins proc_sys_reset_2/aux_reset_in]
 
   # Restore current instance
   current_bd_instance $oldCurInst
@@ -759,6 +774,12 @@ proc avnet_add_pl_dualcam {project projects_folder scriptdir} {
    
   # Create instance: GPIO
   create_hier_cell_GPIO [current_bd_instance .] GPIO
+
+  # Create instance: xlconstant_0, and set properties
+  set xlconstant_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_0 ]
+  set_property -dict [ list \
+   CONFIG.CONST_VAL {0} \
+ ] $xlconstant_0
 
   # MIPI - Create interface ports
   set mipi_phy_if_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:mipi_phy_rtl:1.0 mipi_phy_if_0 ]
@@ -782,28 +803,33 @@ proc avnet_add_pl_dualcam {project projects_folder scriptdir} {
   connect_bd_net -net GPIO_TRG_INPUT [get_bd_ports TRG_INPUT] [get_bd_pins GPIO/TRG_INPUT]
 
   # resets/dcm_locked - Create port connections
-  connect_bd_net -net GPIO_VPSS_RESETn [get_bd_pins CAPTURE_PIPELINE/aux_reset_in_0] [get_bd_pins GPIO/VPSS_RESETn]
-  connect_bd_net -net GPIO_frame_buffer_wr_resetn [get_bd_pins CAPTURE_PIPELINE/aux_reset_in] [get_bd_pins GPIO/frame_buffer_wr_resetn]
+  connect_bd_net -net GPIO_frame_buffer_wr_resetn [get_bd_pins CAPTURE_PIPELINE/frmbuf_resetn] [get_bd_pins GPIO/frame_buffer_wr_resetn]
+  connect_bd_net -net GPIO_vpss_csc_resetn [get_bd_pins CAPTURE_PIPELINE/vpss_csc_resetn] [get_bd_pins GPIO/vpss_csc_resetn]
+  connect_bd_net -net GPIO_vpss_scaler_resetn [get_bd_pins CAPTURE_PIPELINE/vpss_scaler_resetn] [get_bd_pins GPIO/vpss_scaler_resetn]
   connect_bd_net [get_bd_pins CAPTURE_PIPELINE/dcm_locked] [get_bd_pins clk_wiz_0/locked]
   connect_bd_net -net zynq_ultra_ps_e_0_pl_resetn0 [get_bd_pins CAPTURE_PIPELINE/ext_reset_in] [get_bd_pins zynq_ultra_ps_e_0/pl_resetn0]
 
   # Interrupts - Create port connections
+  connect_bd_net [get_bd_pins xlconstant_0/dout] [get_bd_pins xlconcat_0/In0] [get_bd_pins xlconcat_0/In3] [get_bd_pins xlconcat_0/In4] [get_bd_pins xlconcat_0/In5]
   connect_bd_net -net CAPTURE_PIPELINE_interrupt [get_bd_pins CAPTURE_PIPELINE/interrupt] [get_bd_pins xlconcat_0/In1]
   connect_bd_net -net CAPTURE_PIPELINE_csirxss_csi_irq [get_bd_pins CAPTURE_PIPELINE/csirxss_csi_irq] [get_bd_pins xlconcat_0/In2]
 
+  save_bd_design
+
   # Connection Automation for GPIO cores (AXI_GPIO)
-  set_property name clk100 [get_bd_pins GPIO/clk200]
   apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/zynq_ultra_ps_e_0/pl_clk0 (100 MHz)} Clk_slave {Auto} Clk_xbar {/zynq_ultra_ps_e_0/pl_clk0 (100 MHz)} Master {/zynq_ultra_ps_e_0/M_AXI_HPM0_FPD} Slave {/GPIO/axi_gpio_0/S_AXI} ddr_seg {Auto} intc_ip {/ps8_0_axi_periph} master_apm {0}}  [get_bd_intf_pins GPIO/axi_gpio_0/S_AXI]
   # Slave segment '/GPIO/axi_gpio_0/S_AXI/Reg' is being assigned into address space '/zynq_ultra_ps_e_0/Data' at <0xA00A_0000 [ 64K ]>.
 
   # Connection Automation for CAPTURE_PIPELINE control interfaces (MIPI_CSI2_RX, VPSS, FRAMEBUF_WRITE)
-  #INFO: [PSU-1]  DP_AUDIO clock source: RPLL is also being used by other peripheral clocks. Their outputs may get impacted if any driver changes DP_AUDIO PLL source to support runtime audio change 
-  apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {Auto} Clk_slave {Auto} Clk_xbar {/clk_wiz_0/clk_out5 (200 MHz)} Master {/zynq_ultra_ps_e_0/M_AXI_HPM1_FPD} Slave {/CAPTURE_PIPELINE/mipi_csi2_rx_subsyst_0/csirxss_s_axi} ddr_seg {Auto} intc_ip {New AXI Interconnect} master_apm {0}}  [get_bd_intf_pins CAPTURE_PIPELINE/mipi_csi2_rx_subsyst_0/csirxss_s_axi]
+  apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_0/clk_out5 (200 MHz)} Clk_slave {/clk_wiz_0/clk_out5 (200 MHz)} Clk_xbar {/clk_wiz_0/clk_out5 (200 MHz)} Master {/zynq_ultra_ps_e_0/M_AXI_HPM1_FPD} Slave {/CAPTURE_PIPELINE/mipi_csi2_rx_subsyst_0/csirxss_s_axi} ddr_seg {Auto} intc_ip {New AXI Interconnect} master_apm {0}}  [get_bd_intf_pins CAPTURE_PIPELINE/mipi_csi2_rx_subsyst_0/csirxss_s_axi]
   #Slave segment '/CAPTURE_PIPELINE/mipi_csi2_rx_subsyst_0/csirxss_s_axi/Reg' is being assigned into address space '/zynq_ultra_ps_e_0/Data' at <0xB000_0000 [ 8K ]>.
-  apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_0/clk_out5 (200 MHz)} Clk_slave {/clk_wiz_0/clk_out5 (200 MHz)} Clk_xbar {/clk_wiz_0/clk_out5 (200 MHz)} Master {/zynq_ultra_ps_e_0/M_AXI_HPM1_FPD} Slave {/CAPTURE_PIPELINE/v_proc_ss_0/s_axi_ctrl} ddr_seg {Auto} intc_ip {/ps8_0_axi_periph_1} master_apm {0}}  [get_bd_intf_pins CAPTURE_PIPELINE/v_proc_ss_0/s_axi_ctrl]
+  apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_0/clk_out5 (200 MHz)} Clk_slave {/clk_wiz_0/clk_out5 (200 MHz)} Clk_xbar {/clk_wiz_0/clk_out5 (200 MHz)} Master {/zynq_ultra_ps_e_0/M_AXI_HPM1_FPD} Slave {/CAPTURE_PIPELINE/v_proc_ss_scaler_0/s_axi_ctrl} ddr_seg {Auto} intc_ip {/ps8_0_axi_periph_1} master_apm {0}}  [get_bd_intf_pins CAPTURE_PIPELINE/v_proc_ss_scaler_0/s_axi_ctrl]
   #Slave segment '/CAPTURE_PIPELINE/v_proc_ss_0/s_axi_ctrl/Reg' is being assigned into address space '/zynq_ultra_ps_e_0/Data' at <0xB004_0000 [ 256K ]>.
-  apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_0/clk_out5 (200 MHz)} Clk_slave {/clk_wiz_0/clk_out5 (200 MHz)} Clk_xbar {/clk_wiz_0/clk_out5 (200 MHz)} Master {/zynq_ultra_ps_e_0/M_AXI_HPM1_FPD} Slave {/CAPTURE_PIPELINE/v_frmbuf_wr_0/s_axi_CTRL} ddr_seg {Auto} intc_ip {/ps8_0_axi_periph_1} master_apm {0}}  [get_bd_intf_pins CAPTURE_PIPELINE/v_frmbuf_wr_0/s_axi_CTRL]
+  apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_0/clk_out5 (200 MHz)} Clk_slave {/clk_wiz_0/clk_out5 (200 MHz)} Clk_xbar {/clk_wiz_0/clk_out5 (200 MHz)} Master {/zynq_ultra_ps_e_0/M_AXI_HPM1_FPD} Slave {/CAPTURE_PIPELINE/v_frmbuf_wr_0/s_axi_ctrl} ddr_seg {Auto} intc_ip {/ps8_0_axi_periph_1} master_apm {0}}  [get_bd_intf_pins CAPTURE_PIPELINE/v_frmbuf_wr_0/s_axi_ctrl]
   #Slave segment '/CAPTURE_PIPELINE/v_frmbuf_wr_0/s_axi_CTRL/Reg' is being assigned into address space '/zynq_ultra_ps_e_0/Data' at <0xB001_0000 [ 64K ]>.
+  apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_0/clk_out5 (200 MHz)} Clk_slave {/clk_wiz_0/clk_out5 (200 MHz)} Clk_xbar {/clk_wiz_0/clk_out5 (200 MHz)} Master {/zynq_ultra_ps_e_0/M_AXI_HPM1_FPD} Slave {/CAPTURE_PIPELINE/v_proc_ss_csc_0/s_axi_ctrl} ddr_seg {Auto} intc_ip {/ps8_0_axi_periph_1} master_apm {0}}  [get_bd_intf_pins CAPTURE_PIPELINE/v_proc_ss_csc_0/s_axi_ctrl]
+
+  save_bd_design
 
   # Connection Automation for CAPTURE PIPELINE data interface (FRAMEBUF_WRITE)
   #INFO: [PSU-1]  DP_AUDIO clock source: RPLL is also being used by other peripheral clocks. Their outputs may get impacted if any driver changes DP_AUDIO PLL source to support runtime audio change 
@@ -814,5 +840,8 @@ proc avnet_add_pl_dualcam {project projects_folder scriptdir} {
   #Slave segment '/zynq_ultra_ps_e_0/SAXIGP2/HP0_DDR_LOW' is being assigned into address space '/CAPTURE_PIPELINE/v_frmbuf_wr_0/Data_m_axi_mm_video' at <0x0000_0000 [ 2G ]>.
   assign_bd_address -target_address_space /CAPTURE_PIPELINE/v_frmbuf_wr_0/Data_m_axi_mm_video [get_bd_addr_segs zynq_ultra_ps_e_0/SAXIGP2/HP0_LPS_OCM] -force
   #Slave segment '/zynq_ultra_ps_e_0/SAXIGP2/HP0_LPS_OCM' is being assigned into address space '/CAPTURE_PIPELINE/v_frmbuf_wr_0/Data_m_axi_mm_video' at <0xFF00_0000 [ 16M ]>.
+
+  save_bd_design
+
 }
 


### PR DESCRIPTION
u96v2_sbc_dualcam: 
- add VPSS (color space conversion) core to capture pipeline
- add BGR format to FrameBufferWrite core in capture pipeline
- fix vitis interrupts (connect axi_intc back to offset [6], instead of [0] on ps_pl_irq0)