### PR TITLE
Update axi_intc setting and some other TCL cleanup

### DIFF
--- a/boards/mz7010_som/base/mz7010_som_base.tcl
+++ b/boards/mz7010_som/base/mz7010_som_base.tcl
@@ -153,9 +153,12 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    CONFIG.NUM_PORTS {1} \
    ] [get_bd_cells xlconcat_0]
    
+   # Add AXI interrupt controller (for VITIS XRT interrupt support)
    set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
-   # Set interrupt output to 'single' instead of 'bus'
-   set_property -dict [list CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
+   set_property -dict [ list \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    
    # Add constant set to '0'.  We will connect this to the PS SDIO_0 WP input
    create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_0

--- a/boards/mz7020_som/base/mz7020_som_base.tcl
+++ b/boards/mz7020_som/base/mz7020_som_base.tcl
@@ -154,7 +154,12 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    CONFIG.NUM_PORTS {1} \
    ] [get_bd_cells xlconcat_0]
    
+   # Add AXI interrupt controller (for VITIS XRT interrupt support)
    set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
+   set_property -dict [ list \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
 
    # Add constant set to '0'.  We will connect this to the PS SDIO_0 WP input
    create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_0

--- a/boards/pz7010_fmc2/base/pz7010_fmc2_base.tcl
+++ b/boards/pz7010_fmc2/base/pz7010_fmc2_base.tcl
@@ -186,7 +186,12 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
       CONFIG.NUM_PORTS {2} \
    ] [get_bd_cells xlconcat_0]
    
+   # Add AXI interrupt controller (for VITIS XRT interrupt support)
    set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
+   set_property -dict [ list \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
 
    # Add another master port to the AXI interconnect clock so we can connect the axi_intc to it
    set_property -dict [list CONFIG.NUM_MI {4}] [get_bd_cells ps7_axi_periph]

--- a/boards/pz7015_fmc2/base/pz7015_fmc2_base.tcl
+++ b/boards/pz7015_fmc2/base/pz7015_fmc2_base.tcl
@@ -193,7 +193,12 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
       CONFIG.NUM_PORTS {2} \
    ] [get_bd_cells xlconcat_0]
    
+   # Add AXI interrupt controller (for VITIS XRT interrupt support)
    set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
+   set_property -dict [ list \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
 
    # Add another master port to the AXI interconnect clock so we can connect the axi_intc to it
    set_property -dict [list CONFIG.NUM_MI {4}] [get_bd_cells ps7_axi_periph]

--- a/boards/pz7020_fmc2/base/pz7020_fmc2_base.tcl
+++ b/boards/pz7020_fmc2/base/pz7020_fmc2_base.tcl
@@ -200,7 +200,12 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
       CONFIG.NUM_PORTS {2} \
    ] [get_bd_cells xlconcat_0]
    
+   # Add AXI interrupt controller (for VITIS XRT interrupt support)
    set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
+   set_property -dict [ list \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
 
    # Add another master port to the AXI interconnect clock so we can connect the axi_intc to it
    set_property -dict [list CONFIG.NUM_MI {4}] [get_bd_cells ps7_axi_periph]

--- a/boards/pz7030_fmc2/base/pz7030_fmc2_base.tcl
+++ b/boards/pz7030_fmc2/base/pz7030_fmc2_base.tcl
@@ -193,7 +193,12 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
       CONFIG.NUM_PORTS {2} \
    ] [get_bd_cells xlconcat_0]
    
+   # Add AXI interrupt controller (for VITIS XRT interrupt support)
    set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
+   set_property -dict [ list \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
 
    # Add another master port to the AXI interconnect clock so we can connect the axi_intc to it
    set_property -dict [list CONFIG.NUM_MI {4}] [get_bd_cells ps7_axi_periph]

--- a/boards/u96v2_sbc/base/u96v2_sbc_base.tcl
+++ b/boards/u96v2_sbc/base/u96v2_sbc_base.tcl
@@ -360,9 +360,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/u96v2_sbc/base/u96v2_sbc_base.tcl
+++ b/boards/u96v2_sbc/base/u96v2_sbc_base.tcl
@@ -359,10 +359,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/u96v2_sbc/dualcam/u96v2_sbc_dualcam.tcl
+++ b/boards/u96v2_sbc/dualcam/u96v2_sbc_dualcam.tcl
@@ -202,10 +202,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__S_AXI_GP2 {1}] [get_bd_cells zynq_ultra_ps_e_0]
   
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/u96v2_sbc/dualcam/u96v2_sbc_dualcam.tcl
+++ b/boards/u96v2_sbc/dualcam/u96v2_sbc_dualcam.tcl
@@ -203,9 +203,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
   
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/uz3eg_iocc/base/uz3eg_iocc_base.tcl
+++ b/boards/uz3eg_iocc/base/uz3eg_iocc_base.tcl
@@ -150,10 +150,12 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
+
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md
@@ -259,43 +261,31 @@ proc avnet_add_ps_preset {project projects_folder scriptdir} {
    create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:3.3 zynq_ultra_ps_e_0
    apply_bd_automation -rule xilinx.com:bd_rule:zynq_ultra_ps_e -config {apply_board_preset "1" } [get_bd_cells zynq_ultra_ps_e_0]
 
-   set zynq_ultra_ps_e_0 [get_bd_cells zynq_ultra_ps_e_0]
-   
-   # Turn off the DisplayPort for the basic PetaLinux platform since having 
-   # it enabled is causing 2017.2 PetaLinux to complain about PLL sharing 
-   # when turning the DisplayPort audio on.
-   #set_property -dict [list CONFIG.PSU__VIDEO_REF_CLK__ENABLE {0}] [get_bd_cells zynq_ultra_ps_e_0]
-   #set_property -dict [list CONFIG.PSU__PSS_ALT_REF_CLK__ENABLE {0}] [get_bd_cells zynq_ultra_ps_e_0]
-   #set_property -dict [list CONFIG.PSU__DISPLAYPORT__PERIPHERAL__ENABLE {0}] [get_bd_cells zynq_ultra_ps_e_0]
-
    # Connect the SD card WP pin to MIO44 and pull it down to enable software (PetaLinux) 
    # to mount and write the SD card
-   set_property -dict [list CONFIG.PSU__SD1__GRP_WP__ENABLE {1} CONFIG.PSU_MIO_44_PULLUPDOWN {pulldown}] [get_bd_cells zynq_ultra_ps_e_0]
+   set_property -dict [list CONFIG.PSU__SD1__GRP_WP__ENABLE {1} \
+      CONFIG.PSU_MIO_44_PULLUPDOWN {pulldown}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Set the DP_VIDEO, DP_AUDIO, and DP_STC to their correct PLL sources
-   startgroup
-   set_property -dict [list CONFIG.PSU__CRF_APB__DP_VIDEO_REF_CTRL__SRCSEL {VPLL} CONFIG.PSU__CRF_APB__DP_AUDIO_REF_CTRL__SRCSEL {RPLL} CONFIG.PSU__CRF_APB__DP_STC_REF_CTRL__SRCSEL {RPLL}] [get_bd_cells zynq_ultra_ps_e_0]
-   endgroup
+   set_property -dict [list CONFIG.PSU__CRF_APB__DP_VIDEO_REF_CTRL__SRCSEL {VPLL} \
+      CONFIG.PSU__CRF_APB__DP_AUDIO_REF_CTRL__SRCSEL {RPLL} \
+      CONFIG.PSU__CRF_APB__DP_STC_REF_CTRL__SRCSEL {RPLL}] [get_bd_cells zynq_ultra_ps_e_0]
    
    # Enable DisplayPort and set it to use 2 GTR lanes
-   startgroup
-   set_property -dict [list CONFIG.PSU__DPAUX__PERIPHERAL__IO {MIO 27 .. 30} CONFIG.PSU__DP__LANE_SEL {Dual Higher} CONFIG.PSU__DISPLAYPORT__PERIPHERAL__ENABLE {1}] [get_bd_cells zynq_ultra_ps_e_0]
-   endgroup
+   set_property -dict [list CONFIG.PSU__DPAUX__PERIPHERAL__IO {MIO 27 .. 30} \
+      CONFIG.PSU__DP__LANE_SEL {Dual Higher} \
+      CONFIG.PSU__DISPLAYPORT__PERIPHERAL__ENABLE {1}] [get_bd_cells zynq_ultra_ps_e_0]
 
-   # Set the USB and DisplayPort to their correct reference clocks
-   startgroup
-   set_property -dict [list CONFIG.PSU__USB0__REF_CLK_SEL {Ref Clk0} CONFIG.PSU__DP__REF_CLK_SEL {Ref Clk3}] [get_bd_cells zynq_ultra_ps_e_0]
-   endgroup
+   # Set the USB, SATA, and DisplayPort to their correct reference clocks
+   set_property -dict [list CONFIG.PSU__USB0__REF_CLK_SEL {Ref Clk0} \
+      CONFIG.PSU__SATA__REF_CLK_SEL {Ref Clk1} \
+      CONFIG.PSU__DP__REF_CLK_SEL {Ref Clk3}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Set the TOPSW_MAIN to its correct PLL source
-   startgroup
    set_property -dict [list CONFIG.PSU__CRF_APB__TOPSW_MAIN_CTRL__SRCSEL {DPLL}] [get_bd_cells zynq_ultra_ps_e_0]
-   endgroup
    
    # Set the PCAP_CTRL to its correct PLL source
-   startgroup
    set_property -dict [list CONFIG.PSU__CRL_APB__PCAP_CTRL__SRCSEL {IOPLL}] [get_bd_cells zynq_ultra_ps_e_0]
-   endgroup
 
 }
 

--- a/boards/uz3eg_iocc/base/uz3eg_iocc_base.tcl
+++ b/boards/uz3eg_iocc/base/uz3eg_iocc_base.tcl
@@ -151,9 +151,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
 
    #

--- a/boards/uz3eg_pciec/base/uz3eg_pciec_base.tcl
+++ b/boards/uz3eg_pciec/base/uz3eg_pciec_base.tcl
@@ -150,10 +150,12 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
+
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md
@@ -259,31 +261,35 @@ proc avnet_add_ps_preset {project projects_folder scriptdir} {
    create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:3.3 zynq_ultra_ps_e_0
    apply_bd_automation -rule xilinx.com:bd_rule:zynq_ultra_ps_e -config {apply_board_preset "1" } [get_bd_cells zynq_ultra_ps_e_0]
 
-   set zynq_ultra_ps_e_0 [get_bd_cells zynq_ultra_ps_e_0]
-   
-   # Turn off the DisplayPort for the basic PetaLinux platform since having 
-   # it enabled is causing 2017.2 PetaLinux to complain about PLL sharing 
-   # when turning the DisplayPort audio on.
-   #set_property -dict [list CONFIG.PSU__VIDEO_REF_CLK__ENABLE {0}] [get_bd_cells zynq_ultra_ps_e_0]
-   #set_property -dict [list CONFIG.PSU__PSS_ALT_REF_CLK__ENABLE {0}] [get_bd_cells zynq_ultra_ps_e_0]
-   #set_property -dict [list CONFIG.PSU__DISPLAYPORT__PERIPHERAL__ENABLE {0}] [get_bd_cells zynq_ultra_ps_e_0]
-
-   # Disable PCIe controller as well.
+   # Disable PCIe controller
    set_property -dict [list CONFIG.PSU__PCIE__PERIPHERAL__ENABLE {0}] [get_bd_cells zynq_ultra_ps_e_0]
    
    # Connect the SD card WP pin to MIO44 and pull it down to enable software (PetaLinux) 
    # to mount and write the SD card
-   set_property -dict [list CONFIG.PSU__SD1__GRP_WP__ENABLE {1} CONFIG.PSU_MIO_44_PULLUPDOWN {pulldown}] [get_bd_cells zynq_ultra_ps_e_0]
-   
-   startgroup
-   #set_property -dict [list CONFIG.PSU__DPAUX__PERIPHERAL__IO {MIO 27 .. 30} CONFIG.PSU__DP__LANE_SEL {Single Higher} CONFIG.PSU__DISPLAYPORT__PERIPHERAL__ENABLE {1}] [get_bd_cells zynq_ultra_ps_e_0]
-   set_property -dict [list CONFIG.PSU__DPAUX__PERIPHERAL__IO {MIO 27 .. 30} CONFIG.PSU__USB0__REF_CLK_SEL {Ref Clk0} CONFIG.PSU__DP__LANE_SEL {Single Higher} CONFIG.PSU__DISPLAYPORT__PERIPHERAL__ENABLE {1} CONFIG.PSU__CRF_APB__DP_VIDEO_REF_CTRL__SRCSEL {VPLL} CONFIG.PSU__CRF_APB__DP_AUDIO_REF_CTRL__SRCSEL {RPLL} CONFIG.PSU__CRF_APB__DP_STC_REF_CTRL__SRCSEL {RPLL}] [get_bd_cells zynq_ultra_ps_e_0]
-   endgroup
+   set_property -dict [list CONFIG.PSU__SD1__GRP_WP__ENABLE {1} \
+      CONFIG.PSU_MIO_44_PULLUPDOWN {pulldown}] [get_bd_cells zynq_ultra_ps_e_0]
 
-   startgroup
+   # Enable DisplayPort and set it to use 1 GTR lane
+   set_property -dict [list CONFIG.PSU__DPAUX__PERIPHERAL__IO {MIO 27 .. 30} \
+      CONFIG.PSU__DP__LANE_SEL {Single Higher} \
+      CONFIG.PSU__DISPLAYPORT__PERIPHERAL__ENABLE {1} \
+      CONFIG.PSU__CRF_APB__DP_VIDEO_REF_CTRL__SRCSEL {VPLL} \
+      CONFIG.PSU__CRF_APB__DP_AUDIO_REF_CTRL__SRCSEL {RPLL} \
+      CONFIG.PSU__CRF_APB__DP_STC_REF_CTRL__SRCSEL {RPLL}] [get_bd_cells zynq_ultra_ps_e_0]
+
+   # Set the USB, SATA, and DisplayPort to their correct reference clocks
+   set_property -dict [list CONFIG.PSU__USB0__REF_CLK_SEL {Ref Clk2} \
+      CONFIG.PSU__SATA__REF_CLK_SEL {Ref Clk1} \
+      CONFIG.PSU__DP__REF_CLK_SEL {Ref Clk3}] [get_bd_cells zynq_ultra_ps_e_0]
+
+   # Set the TOPSW_MAIN to its correct PLL source
    set_property -dict [list CONFIG.PSU__CRF_APB__TOPSW_MAIN_CTRL__SRCSEL {DPLL}] [get_bd_cells zynq_ultra_ps_e_0]
-   endgroup
 
+   # Set the PCAP_CTRL to its correct PLL source
+   set_property -dict [list CONFIG.PSU__CRL_APB__PCAP_CTRL__SRCSEL {IOPLL}] [get_bd_cells zynq_ultra_ps_e_0]
+
+   save_bd_design
+   
 }
 
 proc avnet_add_sdsoc_directives {project projects_folder scriptdir} {

--- a/boards/uz3eg_pciec/base/uz3eg_pciec_base.tcl
+++ b/boards/uz3eg_pciec/base/uz3eg_pciec_base.tcl
@@ -151,9 +151,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
 
    #

--- a/boards/uz3eg_pciec/netfmc/uz3eg_pciec_netfmc.tcl
+++ b/boards/uz3eg_pciec/netfmc/uz3eg_pciec_netfmc.tcl
@@ -153,9 +153,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/uz3eg_pciec/netfmc/uz3eg_pciec_netfmc.tcl
+++ b/boards/uz3eg_pciec/netfmc/uz3eg_pciec_netfmc.tcl
@@ -152,10 +152,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/uz7ev_evcc/base/uz7ev_evcc_base.tcl
+++ b/boards/uz7ev_evcc/base/uz7ev_evcc_base.tcl
@@ -152,9 +152,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/uz7ev_evcc/base/uz7ev_evcc_base.tcl
+++ b/boards/uz7ev_evcc/base/uz7ev_evcc_base.tcl
@@ -151,10 +151,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/uz7ev_evcc/hdmi/uz7ev_evcc_hdmi.tcl
+++ b/boards/uz7ev_evcc/hdmi/uz7ev_evcc_hdmi.tcl
@@ -157,10 +157,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/uz7ev_evcc/hdmi/uz7ev_evcc_hdmi.tcl
+++ b/boards/uz7ev_evcc/hdmi/uz7ev_evcc_hdmi.tcl
@@ -158,9 +158,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/uz7ev_evcc/hdmi_v/uz7ev_evcc_hdmi_v.tcl
+++ b/boards/uz7ev_evcc/hdmi_v/uz7ev_evcc_hdmi_v.tcl
@@ -157,10 +157,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/uz7ev_evcc/hdmi_v/uz7ev_evcc_hdmi_v.tcl
+++ b/boards/uz7ev_evcc/hdmi_v/uz7ev_evcc_hdmi_v.tcl
@@ -158,9 +158,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/uz7ev_evcc/hdmi_v_n/uz7ev_evcc_hdmi_v_n.tcl
+++ b/boards/uz7ev_evcc/hdmi_v_n/uz7ev_evcc_hdmi_v_n.tcl
@@ -158,10 +158,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/uz7ev_evcc/hdmi_v_n/uz7ev_evcc_hdmi_v_n.tcl
+++ b/boards/uz7ev_evcc/hdmi_v_n/uz7ev_evcc_hdmi_v_n.tcl
@@ -159,9 +159,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/uz7ev_evcc/nvme/uz7ev_evcc_nvme.tcl
+++ b/boards/uz7ev_evcc/nvme/uz7ev_evcc_nvme.tcl
@@ -153,10 +153,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/uz7ev_evcc/nvme/uz7ev_evcc_nvme.tcl
+++ b/boards/uz7ev_evcc/nvme/uz7ev_evcc_nvme.tcl
@@ -154,9 +154,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/uz7ev_evcc/quadcam_h/uz7ev_evcc_quadcam_h.tcl
+++ b/boards/uz7ev_evcc/quadcam_h/uz7ev_evcc_quadcam_h.tcl
@@ -131,10 +131,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/uz7ev_evcc/quadcam_h/uz7ev_evcc_quadcam_h.tcl
+++ b/boards/uz7ev_evcc/quadcam_h/uz7ev_evcc_quadcam_h.tcl
@@ -132,9 +132,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/uz7ev_evcc/quadcam_h_v/uz7ev_evcc_quadcam_h_v.tcl
+++ b/boards/uz7ev_evcc/quadcam_h_v/uz7ev_evcc_quadcam_h_v.tcl
@@ -131,10 +131,11 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {0}] [get_bd_cells zynq_ultra_ps_e_0]
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
-   set axi_intc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 ]
+   create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
+   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
    set_property -dict [ list \
       CONFIG.C_IRQ_IS_LEVEL {1} \
-   ] $axi_intc_0
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md

--- a/boards/uz7ev_evcc/quadcam_h_v/uz7ev_evcc_quadcam_h_v.tcl
+++ b/boards/uz7ev_evcc/quadcam_h_v/uz7ev_evcc_quadcam_h_v.tcl
@@ -132,9 +132,9 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
 
    # Add AXI interrupt controller (for VITIS XRT interrupt support)
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0 
-   # Set IRQ type to 'LEVEL' and connection to 'SINGLE'
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
    set_property -dict [ list \
-      CONFIG.C_IRQ_IS_LEVEL {1} \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
       CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
    #
    # specific to Vitis 2019.2, no longer applicable for Vitis 2020.1

--- a/boards/xbzu1_sbc/dualcam/xbzu1_sbc_dualcam.tcl
+++ b/boards/xbzu1_sbc/dualcam/xbzu1_sbc_dualcam.tcl
@@ -181,6 +181,10 @@ proc avnet_add_user_io_preset {project projects_folder scriptdir} {
    # Vitis interrupt
    #
    create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 axi_intc_0
+   # Set IRQ type to 'EDGE' and connection to 'SINGLE'
+   set_property -dict [ list \
+      CONFIG.C_IRQ_IS_LEVEL {0} \
+      CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_0]
 
    #
    # System peripherals interrupts


### PR DESCRIPTION
I found out from a support case I had open with Xilinx that the axi_intc devicetree settings changed for 2021.1.  This PR also fixes the broken USB on the UltraZed-EG.