### PR TITLE
Update Frame Buffer IP version to 2.4 for Ultra96 Dualcam

### DIFF
--- a/boards/u96v2_sbc/dualcam/u96v2_sbc_dualcam.tcl
+++ b/boards/u96v2_sbc/dualcam/u96v2_sbc_dualcam.tcl
@@ -691,7 +691,7 @@ proc create_hier_cell_CAPTURE_PIPELINE { parentCell nameHier } {
   set proc_sys_reset_3 [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 proc_sys_reset_3 ]
 
   # Create instance: v_frmbuf_wr_0, and set properties
-  set v_frmbuf_wr_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_frmbuf_wr:2.3 v_frmbuf_wr_0 ]
+  set v_frmbuf_wr_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_frmbuf_wr:2.4 v_frmbuf_wr_0 ]
   set_property -dict [ list \
    CONFIG.AXIMM_DATA_WIDTH {128} \
    CONFIG.C_M_AXI_MM_VIDEO_DATA_WIDTH {128} \


### PR DESCRIPTION
For Vivado 2022.1, the Frame Buffer (`v_frmbuf_wr_0`) IP version required to be updated to 2.4 in the scripts. 

This is required for the Ultra96 Dualcam design `u96v2_sbc_dualcam`.