### PR TITLE
Update zub1cg_sbc dualcam IP version for Vivado 2022.1

### DIFF
--- a/boards/zub1cg_sbc/dualcam/zub1cg_sbc_dualcam.tcl
+++ b/boards/zub1cg_sbc/dualcam/zub1cg_sbc_dualcam.tcl
@@ -575,7 +575,7 @@ proc create_hier_cell_CAPTURE_PIPELINE { parentCell nameHier } {
    create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 proc_sys_reset_3
 
    # Create instance: v_frmbuf_wr_0, and set properties
-   create_bd_cell -type ip -vlnv xilinx.com:ip:v_frmbuf_wr:2.3 v_frmbuf_wr_0
+   create_bd_cell -type ip -vlnv xilinx.com:ip:v_frmbuf_wr:2.4 v_frmbuf_wr_0
    set_property -dict [ list \
       CONFIG.AXIMM_DATA_WIDTH {128} \
       CONFIG.C_M_AXI_MM_VIDEO_DATA_WIDTH {128} \


### PR DESCRIPTION
Small change to the IP revision for the Framebuffer IP to v2.4. This is a same change that was required for the `u96v2_dualcam` design to syntheses. 