### PR TITLE
Add IP and Vitis directives for zub1cg_sbc_valtest

### DIFF
--- a/scripts/project_scripts/zub1cg_sbc_valtest.tcl
+++ b/scripts/project_scripts/zub1cg_sbc_valtest.tcl
@@ -153,11 +153,11 @@ if {[string match -nocase "yes" $clean]} {
    }
    
    # Add Vitis directives
-   #~ puts ""
-   #~ puts "***** Adding Vitis directves to design..."
-   #~ avnet_add_vitis_directives ${board}_${project} $projects_folder $scriptdir
-   #~ update_compile_order -fileset sources_1
-   #~ import_files
+   puts ""
+   puts "***** Adding Vitis directves to design..."
+   avnet_add_vitis_directives ${board}_${project} $projects_folder $scriptdir
+   #update_compile_order -fileset sources_1
+   #import_files
    
    # Build the binary
    #*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -200,7 +200,7 @@ if {[string match -nocase "yes" $clean]} {
    open_run impl_1
    puts ""
    puts "***** Write and validate the design archive..."
-   write_hw_platform -fixed -file ${projects_folder}/${board}_${project}.xsa -include_bit -force
+   write_hw_platform -file ${projects_folder}/${board}_${project}.xsa -include_bit -force
    validate_hw_platform ${projects_folder}/${board}_${project}.xsa -verbose
    puts ""
    puts "***** Close the implemented design..."


### PR DESCRIPTION
Adds required IP and directives for Vitis to be able to configure the PL for the Vector Addition sample application (vadd). Only the zub1cg_sbc_valtest design has been modified to support this. This is due the relatively small PL size of `zub1cg_sbc`. The Vitis Kernel is unlikely to therefore fit on the `zub1cg_sbc_dualcam` design due to the video capture pipeline. 

_Other Relevant Pull Requests are:_

- Vitis Build Scripts: https://github.com/Avnet/vitis/pull/5

**TESTING**
Built and run zub1cg_sbc's version of the vadd (Vector Addition Test) which ran successfully. 