### PR TITLE
zub1cg_sbc_dualcam GPIO & Interrupt Fix

### DIFF
--- a/boards/zub1cg_sbc/dualcam/zub1cg_sbc_dualcam.tcl
+++ b/boards/zub1cg_sbc/dualcam/zub1cg_sbc_dualcam.tcl
@@ -266,31 +266,47 @@ proc avnet_add_vitis_directives {project projects_folder scriptdir} {
 
    # define clock and reset ports
    set_property PFM.CLOCK { \
-	clk_out1 {id "0" is_default "true" proc_sys_reset "proc_sys_reset_0" status "fixed"} \
-	clk_out2 {id "1" is_default "false" proc_sys_reset "proc_sys_reset_1" status "fixed"} \
-	clk_out3 {id "2" is_default "false" proc_sys_reset "/proc_sys_reset_2" status "fixed"} \
-	clk_out4 {id "3" is_default "false" proc_sys_reset "/proc_sys_reset_3" status "fixed"} \
-	clk_out5 {id "4" is_default "false" proc_sys_reset "/proc_sys_reset_4" status "fixed"} \
-	clk_out6 {id "5" is_default "false" proc_sys_reset "/proc_sys_reset_5" status "fixed"} \
-	clk_out7 {id "6" is_default "false" proc_sys_reset "/proc_sys_reset_6" status "fixed"} \
+   clk_out1 {id "0" is_default "true" proc_sys_reset "proc_sys_reset_0" status "fixed"} \
+   clk_out2 {id "1" is_default "false" proc_sys_reset "proc_sys_reset_1" status "fixed"} \
+   clk_out3 {id "2" is_default "false" proc_sys_reset "/proc_sys_reset_2" status "fixed"} \
+   clk_out4 {id "3" is_default "false" proc_sys_reset "/proc_sys_reset_3" status "fixed"} \
+   clk_out5 {id "4" is_default "false" proc_sys_reset "/proc_sys_reset_4" status "fixed"} \
+   clk_out6 {id "5" is_default "false" proc_sys_reset "/proc_sys_reset_5" status "fixed"} \
+   clk_out7 {id "6" is_default "false" proc_sys_reset "/proc_sys_reset_6" status "fixed"} \
    } [get_bd_cells /clk_wiz_0]
 
    # define AXI ports
    set_property PFM.AXI_PORT { \
-	M_AXI_HPM1_FPD {memport "M_AXI_GP"} \
-	S_AXI_HPC0_FPD {memport "S_AXI_HPC" sptag "HPC0" memory "zynq_ultra_ps_e_0 HPC0_DDR_LOW"} \
-	S_AXI_HPC1_FPD {memport "S_AXI_HPC" sptag "HPC1" memory "zynq_ultra_ps_e_0 HPC1_DDR_LOW"} \
-	S_AXI_HP0_FPD {memport "S_AXI_HP" sptag "HP0" memory "zynq_ultra_ps_e_0 HP0_DDR_LOW"} \
-	S_AXI_HP1_FPD {memport "S_AXI_HP" sptag "HP1" memory "zynq_ultra_ps_e_0 HP1_DDR_LOW"} \
-	S_AXI_HP2_FPD {memport "S_AXI_HP" sptag "HP2" memory "zynq_ultra_ps_e_0 HP2_DDR_LOW"} \
-	S_AXI_HP3_FPD {memport "S_AXI_HP" sptag "HP3" memory "zynq_ultra_ps_e_0 HP3_DDR_LOW"} \
+   S_AXI_HPC0_FPD {memport "S_AXI_HPC" sptag "HPC0" memory "zynq_ultra_ps_e_0 HPC0_DDR_LOW"} \
+   S_AXI_HPC1_FPD {memport "S_AXI_HPC" sptag "HPC1" memory "zynq_ultra_ps_e_0 HPC1_DDR_LOW"} \
+   S_AXI_HP0_FPD {memport "S_AXI_HP" sptag "HP0" memory "zynq_ultra_ps_e_0 HP0_DDR_LOW"} \
+   S_AXI_HP1_FPD {memport "S_AXI_HP" sptag "HP1" memory "zynq_ultra_ps_e_0 HP1_DDR_LOW"} \
+   S_AXI_HP2_FPD {memport "S_AXI_HP" sptag "HP2" memory "zynq_ultra_ps_e_0 HP2_DDR_LOW"} \
+   S_AXI_HP3_FPD {memport "S_AXI_HP" sptag "HP3" memory "zynq_ultra_ps_e_0 HP3_DDR_LOW"} \
    } [get_bd_cells /zynq_ultra_ps_e_0]
-
+  set_property PFM.AXI_PORT { \
+       M03_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M04_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M05_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M06_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M07_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M08_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M09_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M10_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M11_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M12_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M13_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M14_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M15_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+       M16_AXI {memport "M_AXI_GP" sptag "" memory "" is_range "false"} \
+   } [get_bd_cells /axi_interconnect_0]
+   
    # required for Vitis 2020.1
    # reference : https://github.com/Xilinx/Vitis-In-Depth-Tutorial/blob/master/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step1.md
    # define interrupt ports
-   set_property PFM.IRQ {intr {id 0 range 32}} [get_bd_cells /axi_intc_0]
-  
+   #~ set_property PFM.IRQ {intr {id 0 range 32}} [get_bd_cells /axi_intc_0]
+   set_property PFM.IRQ {pl_ps_irq1 {id 0 range 7}} [get_bd_cells /zynq_ultra_ps_e_0]
+
    # Set platform project properties
    set_property platform.description                   "Base ZUBoard-1CG development platform" [current_project]
    set_property platform.uses_pr                       false         [current_project]
@@ -363,6 +379,9 @@ proc create_hier_cell_GPIO { parentCell nameHier } {
    create_bd_pin -dir O -from 0 -to 0 trigger
    create_bd_pin -dir O -from 0 -to 0 vpss_csc_resetn
    create_bd_pin -dir O -from 0 -to 0 vpss_scaler_resetn
+   create_bd_pin -dir O -from 0 -to 0 rst
+   create_bd_pin -dir O -from 0 -to 0 stby
+
    create_bd_pin -dir I -type clk clk100
    create_bd_pin -dir O -from 0 -to 0 frame_buffer_rd_resetn
    create_bd_pin -dir O -from 0 -to 0 frame_buffer_wr_resetn
@@ -421,20 +440,47 @@ proc create_hier_cell_GPIO { parentCell nameHier } {
       CONFIG.DIN_WIDTH {8} \
       CONFIG.DOUT_WIDTH {1}] [get_bd_cells xlslice_5]
 
+   # Create instance: xlslice_6, and set properties
+   create_bd_cell -type ip -vlnv xilinx.com:ip:xlslice:1.0 xlslice_6
+   set_property -dict [ list \
+      CONFIG.DIN_FROM {6} \
+      CONFIG.DIN_TO {6} \
+      CONFIG.DIN_WIDTH {8} \
+      CONFIG.DOUT_WIDTH {1}] [get_bd_cells xlslice_6]
+
+   # Create instance: xlslice_7, and set properties
+   create_bd_cell -type ip -vlnv xilinx.com:ip:xlslice:1.0 xlslice_7
+   set_property -dict [ list \
+      CONFIG.DIN_FROM {7} \
+      CONFIG.DIN_TO {7} \
+      CONFIG.DIN_WIDTH {8} \
+      CONFIG.DOUT_WIDTH {1}] [get_bd_cells xlslice_7]
+
+
+
    # Create interface connections
    connect_bd_intf_net [get_bd_intf_pins S_AXI] [get_bd_intf_pins axi_gpio_0/S_AXI]
 
    # Create port connections
-   connect_bd_net [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_0/Din] [get_bd_pins xlslice_1/Din] [get_bd_pins xlslice_2/Din] [get_bd_pins xlslice_3/Din] [get_bd_pins xlslice_4/Din] [get_bd_pins xlslice_5/Din]
    connect_bd_net [get_bd_pins clk100] [get_bd_pins axi_gpio_0/s_axi_aclk]
    connect_bd_net [get_bd_pins s_axi_aresetn] [get_bd_pins axi_gpio_0/s_axi_aresetn]
-   connect_bd_net [get_bd_pins trigger] [get_bd_pins xlslice_0/Dout]
-   connect_bd_net [get_bd_pins icp3_i2c_id_select] [get_bd_pins xlslice_1/Dout]
-   connect_bd_net [get_bd_pins sp3] [get_bd_pins xlslice_2/Dout]
-   connect_bd_net [get_bd_pins frame_buffer_wr_resetn] [get_bd_pins xlslice_3/Dout]
-   connect_bd_net [get_bd_pins frame_buffer_rd_resetn] [get_bd_pins xlslice_4/Dout]
-   connect_bd_net [get_bd_pins vpss_scaler_resetn] [get_bd_pins xlslice_5/Dout]
-   connect_bd_net [get_bd_pins vpss_csc_resetn] [get_bd_pins xlslice_4/Dout]
+   connect_bd_net [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_0/Din]
+   connect_bd_net [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_1/Din]
+   connect_bd_net [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_2/Din]
+   connect_bd_net [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_3/Din]
+   connect_bd_net [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_4/Din]
+   connect_bd_net [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_5/Din]
+   connect_bd_net [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_6/Din]
+   connect_bd_net [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_7/Din]
+   connect_bd_net [get_bd_pins xlslice_0/Dout] [get_bd_pins trigger]
+   connect_bd_net [get_bd_pins xlslice_1/Dout] [get_bd_pins icp3_i2c_id_select]
+   connect_bd_net [get_bd_pins xlslice_2/Dout] [get_bd_pins sp3]
+   connect_bd_net [get_bd_pins xlslice_3/Dout] [get_bd_pins frame_buffer_wr_resetn]
+   connect_bd_net [get_bd_pins xlslice_4/Dout] [get_bd_pins frame_buffer_rd_resetn]
+   connect_bd_net [get_bd_pins xlslice_4/Dout] [get_bd_pins vpss_csc_resetn]
+   connect_bd_net [get_bd_pins xlslice_5/Dout] [get_bd_pins vpss_scaler_resetn]
+   connect_bd_net [get_bd_pins xlslice_6/Dout] [get_bd_pins rst]
+   connect_bd_net [get_bd_pins xlslice_7/Dout] [get_bd_pins stby]
 
    # Perform GUI Layout
    regenerate_bd_layout -hierarchy [get_bd_cells /GPIO]
@@ -819,12 +865,16 @@ proc avnet_add_pl_dualcam {project projects_folder scriptdir} {
    create_bd_port -dir O -from 0 -to 0 icp3_i2c_id_select
    create_bd_port -dir O -from 0 -to 0 sp3
    create_bd_port -dir O -from 0 -to 0 trigger
+   create_bd_port -dir O -from 0 -to 0 rst
+   create_bd_port -dir O -from 0 -to 0 stby
 
    # GPIO - Create port connections
    connect_bd_net [get_bd_pins clk_wiz_0/clk_out3] [get_bd_ports clk48m] 
    connect_bd_net [get_bd_pins GPIO/icp3_i2c_id_select] [get_bd_ports icp3_i2c_id_select] 
    connect_bd_net [get_bd_pins GPIO/sp3] [get_bd_ports sp3] 
    connect_bd_net [get_bd_pins GPIO/trigger] [get_bd_ports trigger] 
+   connect_bd_net [get_bd_pins GPIO/rst] [get_bd_ports rst]
+   connect_bd_net [get_bd_pins GPIO/stby] [get_bd_ports stby]
 
    save_bd_design
 
@@ -841,6 +891,9 @@ proc avnet_add_pl_dualcam {project projects_folder scriptdir} {
    connect_bd_net [get_bd_pins CAPTURE_PIPELINE/csirxss_csi_irq] [get_bd_pins xlconcat_1/In0]
    connect_bd_net [get_bd_pins CAPTURE_PIPELINE/interrupt] [get_bd_pins xlconcat_1/In1]
    connect_bd_net [get_bd_pins xlconcat_1/dout] [get_bd_pins zynq_ultra_ps_e_0/pl_ps_irq1]
+
+   connect_bd_net [get_bd_pins CAPTURE_PIPELINE/csirxss_csi_irq] [get_bd_pins xlconcat_0/In3]
+   connect_bd_net [get_bd_pins CAPTURE_PIPELINE/interrupt] [get_bd_pins xlconcat_0/In4]
 
    connect_bd_net [get_bd_pins clk_wiz_0/clk_out5] [get_bd_pins zynq_ultra_ps_e_0/saxihp0_fpd_aclk]
 

--- a/boards/zub1cg_sbc/dualcam/zub1cg_sbc_dualcam.xdc
+++ b/boards/zub1cg_sbc/dualcam/zub1cg_sbc_dualcam.xdc
@@ -20,16 +20,22 @@ set_property PACKAGE_PIN J2 [get_ports {trigger[0]}]; # HP_DP_13_GC_N
 set_property PACKAGE_PIN J3 [get_ports {icp3_i2c_id_select[0]}]; # HP_DP_13_GC_P
 set_property PACKAGE_PIN N3 [get_ports {sp3[0]}]; # HP_SE_01
 set_property PACKAGE_PIN L3 [get_ports clk48m]; # HP_DP_12_GC_N
+set_property PACKAGE_PIN C3 [get_ports {rst[0]}]; # HP_DP_22_N
+set_property PACKAGE_PIN L4 [get_ports {stby[0]}]; # HP_DP_12_GC_P
 
 set_property IOSTANDARD LVCMOS12 [get_ports {icp3_i2c_id_select[0]}]
 set_property IOSTANDARD LVCMOS12 [get_ports {sp3[0]}]
 set_property IOSTANDARD LVCMOS12 [get_ports {trigger[0]}]
 set_property IOSTANDARD LVCMOS12 [get_ports clk48m]
+set_property IOSTANDARD LVCMOS12 [get_ports {rst[0]}]
+set_property IOSTANDARD LVCMOS12 [get_ports {stby[0]}]
 
 set_property DRIVE 8 [get_ports {icp3_i2c_id_select[0]}]
 set_property DRIVE 8 [get_ports {sp3[0]}]
 set_property DRIVE 8  [get_ports {trigger[0]}]
 set_property DRIVE 8 [get_ports clk48m]
+set_property DRIVE 8 [get_ports {rst[0]}]
+set_property DRIVE 8 [get_ports {stby[0]}]
 
 #
 # ISP I2C & SPI


### PR DESCRIPTION
Small changes to allow the zub1cg_sbc_dualcam to work. 

Due to a botched merge, pins (as below) which are essential for the AP1302 to operate were missing from the scripts to create and modify the Vivado project. Therefore, AP1302 was unable to be reset  
- I2C Address Select Pin
- Reset 
- Standby

Additionally, the interrupt from the AP1302 into the PS was incorrectly configured to the incorrect input. 